### PR TITLE
add .zig-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gdb_history
+.zig-cache/
 zig-cache/
 zig-out/
 docs/


### PR DESCRIPTION
Just a wee little pr to add .zig-cache to the gitignore (this is new since 0.13.0).