### PR TITLE
use target and optimize

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,27 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
     const entry = b.path("src/root.zig");
-    const lib = b.addModule("datetime", .{ .root_source_file = entry });
-    const lib_unit_tests = b.addTest(.{ .root_source_file = entry });
+    const lib = b.addModule("datetime", .{
+        .root_source_file = entry,
+        .target = target,
+        .optimize = optimize,
+    });
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = entry,
+        .target = target,
+        .optimize = optimize,
+    });
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const demo = b.addTest(.{
         .name = "demo",
         .root_source_file = b.path("demos.zig"),
+        .target = target,
+        .optimize = optimize,
     });
     demo.root_module.addImport("datetime", lib);
     const run_demo = b.addRunArtifact(demo);


### PR DESCRIPTION
This is an extremely optional pr but wanted to share just in case it's useful.

I was getting these errors running `zig build` in a zig project and it didn't make any sense:

```
error: invalid option: -Dcpu
error: invalid option: -Dtarget
error: invalid option: -Doptimize
```

It took me a while to find this zig issue (https://github.com/ziglang/zig/issues/18575) and realize it was happening because of a dependency.

Ideally we would just skip using target and optimize in libs if not really used, though until the above error message issue is fixed it seems nice to help avoid footguns by still accepting those options in libs.