### PR TITLE
Update to Zig 0.15.1

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
       - run: zig build-lib src/root.zig -femit-docs=docs -fno-emit-bin
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
       - run: zig build test

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Generic Date, Time, and DateTime library.
 
 ## Installation
 ```sh
+zig fetch --save "git+https://github.com/clickingbuttons/datetime.git"
+# or
 zig fetch --save "https://github.com/clickingbuttons/datetime/archive/refs/tags/0.14.0.tar.gz"
 ```
 
@@ -29,21 +31,51 @@ const datetime = @import("datetime");
 
 test "now" {
     const date = datetime.Date.now();
-    std.debug.print("today's date is {rfc3339}\n", .{ date });
+    std.debug.print("today's date is {f}\n", .{date});
 
     const time = datetime.Time.now();
-    std.debug.print("today's time is {rfc3339}\n", .{ time });
+    std.debug.print("today's time is {f}\n", .{time});
 
     const nanotime = datetime.time.Nano.now();
-    std.debug.print("today's nanotime is {rfc3339}\n", .{ nanotime });
+    std.debug.print("today's nanotime is {f}\n", .{nanotime});
 
     const dt = datetime.DateTime.now();
-    std.debug.print("today's date and time is {rfc3339}\n", .{ dt });
+    std.debug.print("today's date and time is {f}\n", .{dt});
 
     const NanoDateTime = datetime.datetime.Advanced(datetime.Date, datetime.time.Nano, false);
     const ndt = NanoDateTime.now();
-    std.debug.print("today's date and nanotime is {rfc3339}\n", .{ ndt });
+    std.debug.print("today's date and nanotime is {f}\n", .{ndt});
 }
+```
+
+### Formatting Options
+
+**RFC3339 Format (default):** The `{f}` format specifier outputs RFC3339 format by default:
+
+```zig
+const date = datetime.Date.init(2025, .jul, 20);
+const time = datetime.time.Milli.init(15, 30, 45, 123);
+const dt = datetime.DateTime.init(2025, .jul, 20, 15, 30, 45, 0, 0);
+
+std.debug.print("Date: {f}\n", .{date});     // Output: 2025-07-20
+std.debug.print("Time: {f}\n", .{time});     // Output: 15:30:45.123
+std.debug.print("DateTime: {f}\n", .{dt});   // Output: 2025-07-20T15:30:45Z
+```
+
+**Struct Format (for debugging):** Use the `formatStruct` method for debug-style output:
+
+```zig
+var buf: [256]u8 = undefined;
+var writer = std.io.Writer.fixed(&buf);
+
+try date.formatStruct(&writer);
+std.debug.print("Date: {s}\n", .{writer.buffered()});
+// Output: Date{ .year = 2025, .month = .jul, .day = 20 }
+
+writer = std.io.Writer.fixed(&buf);
+try time.formatStruct(&writer);
+std.debug.print("Time: {s}\n", .{writer.buffered()});
+// Output: Time{ .hour = 15, .minute = 30, .second = 45, .subsecond = 123 }
 ```
 
 Features:
@@ -63,6 +95,8 @@ In-scope, PRs welcome:
 
 ## Why yet another date time library?
 - I frequently use different precisions for years, subseconds, and UTC offsets.
+- Zig standard library [does not have accepted proposal](https://github.com/ziglang/zig/issues/8396).
 - Andrew [rejected this from stdlib.](https://github.com/ziglang/zig/pull/19549#issuecomment-2062091512)
+- [Other implementations](https://github.com/nektro/zig-time/blob/master/time.zig) are outdated and never accepted too.
 
 [^1]: [Euclidean Affine Functions by Cassio and Neri.](https://arxiv.org/pdf/2102.06959)

--- a/build.zig
+++ b/build.zig
@@ -11,19 +11,25 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = entry,
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = entry,
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const demo = b.addTest(.{
         .name = "demo",
-        .root_source_file = b.path("demos.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("demos.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "datetime", .module = lib },
+            },
+        }),
     });
-    demo.root_module.addImport("datetime", lib);
     const run_demo = b.addRunArtifact(demo);
 
     const test_step = b.step("test", "Run unit tests");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .datetime,
-    .version = "0.14.0",
-    .minimum_zig_version = "0.14.0",
+    .version = "0.15.0-dev.1147+69cf40da6",
+    .minimum_zig_version = "0.15.0-dev.1147+69cf40da6",
     .fingerprint = 0x93f3c6cab5757db5, // Changing this has security and trust implications.
     .paths = .{
         "build.zig",

--- a/demos.zig
+++ b/demos.zig
@@ -3,37 +3,65 @@ const datetime = @import("datetime");
 
 test "now" {
     const date = datetime.Date.now();
-    std.debug.print("today's date is {rfc3339}\n", .{ date });
+    std.debug.print("today's date is {f}\n", .{date});
 
     const time = datetime.Time.now();
-    std.debug.print("today's time is {rfc3339}\n", .{ time });
+    std.debug.print("today's time is {f}\n", .{time});
 
     const nanotime = datetime.time.Nano.now();
-    std.debug.print("today's nanotime is {rfc3339}\n", .{ nanotime });
+    std.debug.print("today's nanotime is {f}\n", .{nanotime});
 
     const dt = datetime.DateTime.now();
-    std.debug.print("today's date and time is {rfc3339}\n", .{ dt });
+    std.debug.print("today's date and time is {f}\n", .{dt});
 
     const NanoDateTime = datetime.datetime.Advanced(datetime.Date, datetime.time.Nano, false);
     const ndt = NanoDateTime.now();
-    std.debug.print("today's date and nanotime is {rfc3339}\n", .{ ndt });
+    std.debug.print("today's date and nanotime is {f}\n", .{ndt});
 }
 
 test "iterator" {
-    const from =  datetime.Date.now();
+    const from = datetime.Date.now();
     const to = from.add(.{ .days = 7 });
 
     var i = from;
     while (i.toEpoch() < to.toEpoch()) : (i = i.add(.{ .days = 1 })) {
-        std.debug.print("{s} {rfc3339}\n", .{ @tagName(i.weekday()), i });
+        std.debug.print("{s} {f}\n", .{ @tagName(i.weekday()), i });
     }
 }
 
 test "RFC 3339" {
     const d1 = try datetime.Date.parseRfc3339("2024-04-27");
-    std.debug.print("d1 {rfc3339}\n", .{ d1 });
+    std.debug.print("d1 {f}\n", .{d1});
 
     const DateTimeOffset = datetime.datetime.Advanced(datetime.Date, datetime.time.Sec, true);
     const d2 = try DateTimeOffset.parseRfc3339("2024-04-27T13:03:23-04:00");
-    std.debug.print("d2 {rfc3339}\n", .{ d2 });
+    std.debug.print("d2 {f}\n", .{d2});
+}
+
+test "formatting options" {
+    const date = datetime.Date.init(2025, .jul, 20);
+    const time = datetime.time.Milli.init(15, 30, 45, 123);
+    const dt = datetime.DateTime.init(2025, .jul, 20, 15, 30, 45, 0, 0);
+
+    std.debug.print("\n=== RFC3339 Format (default with {{f}}) ===\n", .{});
+    std.debug.print("Date: {f}\n", .{date});
+    std.debug.print("Time: {f}\n", .{time});
+    std.debug.print("DateTime: {f}\n", .{dt});
+
+    std.debug.print("\n=== Struct Format (for debugging) ===\n", .{});
+
+    // To get struct format, use the formatStruct method directly
+    var buf: [256]u8 = undefined;
+    var writer = std.io.Writer.fixed(&buf);
+
+    try date.formatStruct(&writer);
+    std.debug.print("Date: {s}\n", .{writer.buffered()});
+
+    writer = std.io.Writer.fixed(&buf);
+    try time.formatStruct(&writer);
+    std.debug.print("Time: {s}\n", .{writer.buffered()});
+
+    writer = std.io.Writer.fixed(&buf);
+    try dt.formatStruct(&writer);
+    std.debug.print("DateTime: {s}\n", .{writer.buffered()});
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -17,22 +17,6 @@ pub const Time = time.Sec;
 /// * No timezones.
 pub const DateTime = datetime.Advanced(Date, time.Sec, false);
 
-fn fmtRfc3339Impl(
-    date_time_or_datetime: Date,
-    comptime fmt: []const u8,
-    options: std.fmt.FormatOptions,
-    writer: anytype,
-) !void {
-    _ = fmt;
-    _ = options;
-    try date_time_or_datetime.toRfc3339(writer);
-}
-
-/// Return a RFC 3339 formatter for a Date, Time, or DateTime type.
-pub fn fmtRfc3339(date_time_or_datetime: anytype) std.fmt.Formatter(fmtRfc3339Impl) {
-    return .{ .data = date_time_or_datetime };
-}
-
 /// Tests EpochSeconds -> DateTime and DateTime -> EpochSeconds
 fn testEpoch(secs: DateTime.EpochSubseconds, dt: DateTime) !void {
     const actual_dt = DateTime.fromEpoch(secs);


### PR DESCRIPTION
A follow-up/refinement of #7. This mostly just cleans up a few things and is quite conservative relative to the other branch.

That said, I'm not a fan of having a `fmtRfc3339()` separate from `format()`. I have two questions on that:

1. Do we really need the range check to return a separate error tag?
2. Why is there even a range check to begin with?